### PR TITLE
initialize m_double_pinyin

### DIFF
--- a/src/PYConfig.cc
+++ b/src/PYConfig.cc
@@ -114,6 +114,7 @@ Config::initDefaultValues (void)
     m_init_full_punct = TRUE;
     m_init_simp_chinese = TRUE;
     m_special_phrases = TRUE;
+    m_double_pinyin = FALSE;
     updateContext (PyZy::InputContext::PROPERTY_SPECIAL_PHRASE,
                    PyZy::Variant::fromBool (m_special_phrases));
 }


### PR DESCRIPTION
Some member variables are never initialized, so their values are non-deterministic.
Specially, m_double_pinyin is not initialized. Here it defaults to TRUE which disturbs most people.
Some other variables are also not initialized, including m_guide_key, m_enter_key, m_auxiliary_\* and other member variables of Config. Maybe they should also be initialized.
