### PR TITLE
Enable using Python 3 in ibus-setup-pinyin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,13 @@ LIBS="$save_LIBS"
 AC_PATH_PROG(ENV, env)
 AC_SUBST(ENV)
 
+# Define python version
+AC_ARG_WITH(python,
+    AS_HELP_STRING([--with-python[=PATH]],
+        [Select python2 or python3]),
+    [PYTHON=$with_python], []
+)
+
 # check python
 AM_PATH_PYTHON([2.5])
 
@@ -166,6 +173,7 @@ Build options:
     Version                     $VERSION
     Install prefix              $prefix
     Use boost                   $enable_boost
+    python                      $PYTHON
     Build lua extension         $enable_lua_extension
     Build english input mode    $enable_english_input_mode
 ])

--- a/setup/ibus-setup-pinyin.in
+++ b/setup/ibus-setup-pinyin.in
@@ -26,5 +26,5 @@ export IBUS_PREFIX=@prefix@
 export IBUS_DATAROOTDIR=@datarootdir@
 export IBUS_LOCALEDIR=@localedir@
 cd @prefix@/share/ibus-pinyin/setup/
-exec python main.py $@
+exec @PYTHON@ main.py $@
 

--- a/setup/main.py
+++ b/setup/main.py
@@ -20,6 +20,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from __future__ import print_function
+
 import gettext
 import locale
 import os
@@ -250,8 +252,8 @@ class PreferencesDialog:
 
         def __correct_pinyin_toggled_cb(widget):
             val = widget.get_active()
-            map(lambda w: self.__builder.get_object(w[0]).set_sensitive(val),
-                self.__correct_pinyin_widgets)
+            for w in self.__correct_pinyin_widgets:
+                self.__builder.get_object(w[0]).set_sensitive(val)
         self.__correct_pinyin.connect("toggled", __correct_pinyin_toggled_cb)
 
         # init value
@@ -300,8 +302,8 @@ class PreferencesDialog:
 
         def __fuzzy_pinyin_toggled_cb(widget):
             val = widget.get_active()
-            map(lambda w: self.__builder.get_object(w[0]).set_sensitive(val),
-                self.__fuzzy_pinyin_widgets)
+            for w in self.__fuzzy_pinyin_widgets:
+                self.__builder.get_object(w[0]).set_sensitive(val)
         self.__fuzzy_pinyin.connect("toggled", __fuzzy_pinyin_toggled_cb)
 
         # init value
@@ -404,7 +406,7 @@ class PreferencesDialog:
         elif isinstance(val, str):
             var = GLib.Variant.new_string(val)
         else:
-            print >> sys.stderr, "val(%s) is not in support type." % repr(val)
+            print("val(%s) is not in support type." % repr(val), file=sys.stderr)
             return
 
         self.__values[name] = val


### PR DESCRIPTION
Hello,
This enables setup scripts to run under Python 3, and allows setting the Python interpreter at configure time, using `--with-python=python3`.
