### PR TITLE
Don't set empty preedit by reset when no composing state

### DIFF
--- a/src/PYPhoneticEditor.cc
+++ b/src/PYPhoneticEditor.cc
@@ -32,7 +32,8 @@ namespace PY {
 PhoneticEditor::PhoneticEditor (PinyinProperties & props, Config & config)
     : Editor (props, config),
       m_observer (PinyinObserver(*this)),
-      m_lookup_table (m_config.pageSize ())
+      m_lookup_table (m_config.pageSize ()),
+      m_dont_update_preedit (FALSE)
 {
 }
 
@@ -382,7 +383,18 @@ PhoneticEditor::commit (void)
 void
 PhoneticEditor::reset (void)
 {
+    const String &selected_text = m_context->selectedText ();
+    const String &conversion_text = m_context->conversionText ();
+    const String &rest_text = m_context->restText ();
+
+    if (selected_text.empty () && conversion_text.empty () &&
+        rest_text.empty ())
+        m_dont_update_preedit = TRUE;
+    else
+        m_dont_update_preedit = FALSE;
+
     m_context->reset();
+    m_dont_update_preedit = FALSE;
 }
 
 void
@@ -424,6 +436,9 @@ PhoneticEditor::updateAuxiliaryTextBefore (String &buffer)
 void
 PhoneticEditor::updatePreeditText (void)
 {
+    if (m_dont_update_preedit)
+        return;
+
     const String &selected_text = m_context->selectedText ();
     const String &conversion_text = m_context->conversionText ();
     const String &rest_text = m_context->restText ();

--- a/src/PYPhoneticEditor.h
+++ b/src/PYPhoneticEditor.h
@@ -88,6 +88,7 @@ protected:
     std::unique_ptr<PyZy::InputContext>  m_context;
     PinyinObserver                       m_observer;
     LookupTable                          m_lookup_table;
+    gboolean                             m_dont_update_preedit;
 };
 };
 


### PR DESCRIPTION
This fix is for https://github.com/ibus/ibus/issues/1738

When calling gtk_im_context_reset(), ibus-pinyin send the signals "preedit_start", "preedit_changed" (with emptry predit string), and "preeedit_end".  Even if no composing state, these signals occurs.

This causes some application is unexcpeted behavior.

Chromium
https://bugs.chromium.org/p/chromium/issues/detail?id=404005

Firefox
https://bugzilla.mozilla.org/show_bug.cgi?id=1138159

So when calling gtk_im_context_reset() without composing, ibus-pinyin shouldn't send "preedit_*" signals.
