### PR TITLE
Update lmyoslib.c for new lua 5.4 version

### DIFF
--- a/lua/lmyoslib.c
+++ b/lua/lmyoslib.c
@@ -57,7 +57,7 @@ static int getfield (lua_State *L, const char *key, int d) {
     res = (int)lua_tointeger(L, -1);
   else {
     if (d < 0)
-      return luaL_error(L, "field " LUA_QS " missing in date table", key);
+      return luaL_error(L, "field '%s' missing in date table", key);
     res = d;
   }
   lua_pop(L, 1);


### PR DESCRIPTION
Fix lua 5.4 compatibility, due to deprecated LUA_QS macro

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=964680 for reference