### PR TITLE
Fix sqlite 3.41.0 build failed

### DIFF
--- a/data/db/english/english.awk
+++ b/data/db/english/english.awk
@@ -16,7 +16,7 @@ BEGIN {
 }
 
     # Insert data into english table
-    {   printf "INSERT INTO english (word, freq) VALUES (\"%s\", \"%f\");\n", $1, $2}
+    {   printf "INSERT INTO english (word, freq) VALUES (\'%s\', %f);\n", $1, $2}
 
     #quit sqlite3
 END {


### PR DESCRIPTION
data/db/english/english.awk run failed with sqlite 3.41.0, the error
message is:

```
gawk -f ./english.awk ./wordlist | /usr/bin/sqlite3 english.db || \
	( rm -f english.db ; exit 1 )
Parse error near line 5: no such column: the
  INSERT INTO english (word, freq) VALUES ("the", "6.510891");
                             error here ---^
```
As sqlite 3.41.0 release note say:

 The double-quoted string misfeature is now disabled by default for CLI builds. Legacy use cases can reenable the misfeature at run-time using the ".dbconfig dqs_dml on" and ".dbconfig dqs_ddl on" commands.

We should change this double quote to single quote

Ref: https://bugs.gentoo.org/896366