### PR TITLE
Fix preference dialog breaking issue

### DIFF
--- a/setup/main.py
+++ b/setup/main.py
@@ -45,7 +45,12 @@ class PreferencesDialog:
         locale.setlocale(locale.LC_ALL, "")
         localedir = os.getenv("IBUS_LOCALEDIR")
         gettext.bindtextdomain("ibus-pinyin", localedir)
-        gettext.bind_textdomain_codeset("ibus-pinyin", "UTF-8")
+        # Python's gettext module doesn't provide all methods in
+        # new Python version since Python 3.10
+        try:
+            gettext.bind_textdomain_codeset("ibus-pinyin", "UTF-8")
+        except AttributeError:
+            pass
 
         self.__bus = IBus.Bus()
         self.__config = self.__bus.get_config()


### PR DESCRIPTION
Origin: https://bugs.gentoo.org/905906

## Problem
When trying to open the preference for `Chinese-Pinyin` in `ibus-setup`, an error is thrown:
```
Traceback (most recent call last):
  File "/usr/share/ibus-pinyin/setup/main.py", line 432, in <module>
    main()
  File "/usr/share/ibus-pinyin/setup/main.py", line 428, in main
    PreferencesDialog(name).run()
    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/ibus-pinyin/setup/main.py", line 48, in __init__
    gettext.bind_textdomain_codeset("ibus-pinyin", "UTF-8")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'gettext' has no attribute 'bind_textdomain_codeset'

```

## Cause
The relevant APIs were already removed in Python 3.10:
https://bugs.python.org/issue40936
https://docs.python.org/3.10/library/gettext.html#gettext.bind_textdomain_codeset

This is a UX issue but does prevent basic functionalities. 

Using python >=3.10 will raise this problem.

## Potential Fix
By removing this single line seems to fix the issue. The preference can now function properly
```
File "/usr/share/ibus-pinyin/setup/main.py", line 48, in __init__
    gettext.bind_textdomain_codeset("ibus-pinyin", "UTF-8")
```

No further usages of removed API were found.

## Disclaimer
I haven't performed deeper testing to see if the removal of this line will cause problem elsewhere