### PR TITLE
Avoid input engine respond to the Superkey

### DIFF
--- a/src/PYBopomofoEditor.cc
+++ b/src/PYBopomofoEditor.cc
@@ -151,6 +151,10 @@ BopomofoEditor::processBopomofo (guint keyval, guint keycode, guint modifiers)
 gboolean
 BopomofoEditor::processKeyEvent (guint keyval, guint keycode, guint modifiers)
 {
+
+    if (modifiers & IBUS_MOD4_MASK)
+        return FALSE;
+
     modifiers &= (IBUS_SHIFT_MASK |
                   IBUS_CONTROL_MASK |
                   IBUS_MOD1_MASK |

--- a/src/PYDoublePinyinEditor.cc
+++ b/src/PYDoublePinyinEditor.cc
@@ -66,6 +66,9 @@ DoublePinyinEditor::updateAuxiliaryTextAfter (String &buffer)
 gboolean
 DoublePinyinEditor::processKeyEvent (guint keyval, guint keycode, guint modifiers)
 {
+    if (modifiers & IBUS_MOD4_MASK)
+        return FALSE;
+
     /* handle ';' key */
     if (G_UNLIKELY (keyval == IBUS_semicolon)) {
         if (cmshm_filter (modifiers) == 0) {

--- a/src/PYEditor.cc
+++ b/src/PYEditor.cc
@@ -38,6 +38,9 @@ Editor::~Editor (void)
 gboolean
 Editor::processKeyEvent (guint keyval, guint keycode, guint modifiers)
 {
+    if (modifiers & IBUS_MOD4_MASK)
+        return FALSE;
+
     modifiers &= (IBUS_CONTROL_MASK |
                   IBUS_MOD1_MASK |
                   IBUS_SUPER_MASK |

--- a/src/PYEnglishEditor.cc
+++ b/src/PYEnglishEditor.cc
@@ -375,6 +375,9 @@ EnglishEditor::~EnglishEditor ()
 gboolean
 EnglishEditor::processKeyEvent (guint keyval, guint keycode, guint modifiers)
 {
+    if (modifiers & IBUS_MOD4_MASK)
+        return FALSE;
+
     //IBUS_SHIFT_MASK is removed.
     modifiers &= (IBUS_CONTROL_MASK |
                   IBUS_MOD1_MASK |

--- a/src/PYExtEditor.cc
+++ b/src/PYExtEditor.cc
@@ -76,6 +76,9 @@ ExtEditor::resetLuaState ()
 gboolean
 ExtEditor::processKeyEvent (guint keyval, guint keycode, guint modifiers)
 {
+    if (modifiers & IBUS_MOD4_MASK)
+        return FALSE;
+
     //IBUS_SHIFT_MASK is removed.
     modifiers &= (IBUS_CONTROL_MASK |
                   IBUS_MOD1_MASK |

--- a/src/PYFallbackEditor.cc
+++ b/src/PYFallbackEditor.cc
@@ -205,6 +205,9 @@ FallbackEditor::processKeyEvent (guint keyval, guint keycode, guint modifiers)
 {
     gboolean retval = FALSE;
 
+    if (modifiers & IBUS_MOD4_MASK)
+        return FALSE;
+
     modifiers &= (IBUS_SHIFT_MASK |
                   IBUS_CONTROL_MASK |
                   IBUS_MOD1_MASK |

--- a/src/PYPhoneticEditor.cc
+++ b/src/PYPhoneticEditor.cc
@@ -204,6 +204,9 @@ PhoneticEditor::processFunctionKey (guint keyval, guint keycode, guint modifiers
 gboolean
 PhoneticEditor::processKeyEvent (guint keyval, guint keycode, guint modifiers)
 {
+    if (modifiers & IBUS_MOD4_MASK)
+        return FALSE;
+
     return FALSE;
 }
 

--- a/src/PYPinyinEditor.cc
+++ b/src/PYPinyinEditor.cc
@@ -163,6 +163,9 @@ PinyinEditor::processFunctionKey (guint keyval, guint keycode, guint modifiers)
 gboolean
 PinyinEditor::processKeyEvent (guint keyval, guint keycode, guint modifiers)
 {
+    if (modifiers & IBUS_MOD4_MASK)
+        return FALSE;
+
     modifiers &= (IBUS_SHIFT_MASK |
                   IBUS_CONTROL_MASK |
                   IBUS_MOD1_MASK |

--- a/src/PYPunctEditor.cc
+++ b/src/PYPunctEditor.cc
@@ -146,6 +146,9 @@ PunctEditor::processPunct (guint keyval, guint keycode, guint modifiers)
 gboolean
 PunctEditor::processKeyEvent (guint keyval, guint keycode, guint modifiers)
 {
+    if (modifiers & IBUS_MOD4_MASK)
+        return FALSE;
+
     modifiers &= (IBUS_SHIFT_MASK |
                   IBUS_CONTROL_MASK |
                   IBUS_MOD1_MASK |


### PR DESCRIPTION
Avoid the input engine responding to the Superkey, otherwise, this will cause ibus-pinyin to not switch to other input engines under Wayland.