### PR TITLE
Replace deprecated g_atexit to avoid build warning

### DIFF
--- a/src/PYMain.cc
+++ b/src/PYMain.cc
@@ -185,7 +185,7 @@ main (gint argc, gchar **argv)
 
     ::signal (SIGTERM, sigterm_cb);
     ::signal (SIGINT, sigterm_cb);
-    g_atexit (atexit_cb);
+    atexit (atexit_cb);
 
     start_component ();
     return 0;


### PR DESCRIPTION
Hi @phuang @epico :
I want to make a little modification to replace g_atexit function with standard atexit to avoid warning. with which could make ibus-pinyin build in a restrict source checking condition.
Thank you so much for your time.